### PR TITLE
Remove SimpleSurvey intermediate model, custom json serializer.

### DIFF
--- a/gsadjust/GSadjust.py
+++ b/gsadjust/GSadjust.py
@@ -1961,7 +1961,7 @@ def main():
         logging.basicConfig(filename=fn, format='%(levelname)s:%(message)s', level=logging.INFO)
     except PermissionError:
         show_message('Please install GSadjust somewhere where admin rights are not required.', 'GSadjust error')
-    # sys.excepthook = handle_exception
+    sys.excepthook = handle_exception
 
     splash_pix = QtGui.QPixmap('./gsadjust/resources/Splash.png')
     splash = QtWidgets.QSplashScreen(splash_pix, QtCore.Qt.WindowStaysOnTopHint)

--- a/gsadjust/GSadjust.py
+++ b/gsadjust/GSadjust.py
@@ -1961,7 +1961,7 @@ def main():
         logging.basicConfig(filename=fn, format='%(levelname)s:%(message)s', level=logging.INFO)
     except PermissionError:
         show_message('Please install GSadjust somewhere where admin rights are not required.', 'GSadjust error')
-    sys.excepthook = handle_exception
+    # sys.excepthook = handle_exception
 
     splash_pix = QtGui.QPixmap('./gsadjust/resources/Splash.png')
     splash = QtWidgets.QSplashScreen(splash_pix, QtCore.Qt.WindowStaysOnTopHint)

--- a/gsadjust/data_objects.py
+++ b/gsadjust/data_objects.py
@@ -19,7 +19,7 @@ Datum: Absolute-gravity observation or other reference for the relative-gravity 
  
 Delta: Relative-gravity difference calculated from two station occupations. May or may not include drift correction.
 
-SimpleSurvey | SimpleLoop | SimpleStation: This is a simplified representation of the main ObsTreeSurvey | ObsTreeLoop |
+SimpleLoop | SimpleStation: This is a simplified representation of the main ObsTreeSurvey | ObsTreeLoop |
   ObstreeStation PyQt datastore. The Simple... objects exist because PyQt objects can't be serialized, which is
   mandatory for saving the workspace using pickle (or json).
 
@@ -665,39 +665,6 @@ class Adjustment:
 ###############################################################################
 # Simple.... objects have no PyQT elements, so they can be pickled
 ###############################################################################
-class SimpleSurvey:
-    """
-    Qt objects can't be pickled. For the delta and datum tables, data are only stored in the respective tables,
-    so we need to rewrite them as python objects. For the loop_dic and station_dics, they duplicate the data
-    in the Qt models, so we can't just write the dics and ignore the Qt objects - they'll be recreated when the
-    file loads.
-
-    This also clears adjustment results, which we don't want to save.
-    """
-
-    def __init__(self, survey):
-        self.loops = []
-        self.deltas = []
-        self.datums = []
-        # Remove ObsTreeStation objects from deltas in the survey delta_model (which is different than the individual
-        # loop delta_models; those are recreated when the workspace is loaded.
-        for i in range(survey.delta_model.rowCount()):
-            ind = survey.delta_model.createIndex(i, 0)
-            delta = survey.delta_model.data(ind, QtCore.Qt.UserRole)
-            simpledelta = SimpleDelta(delta)
-            self.deltas.append(simpledelta)
-        for i in range(survey.datum_model.rowCount()):
-            ind = survey.datum_model.createIndex(i, 0)
-            self.datums.append(survey.datum_model.data(ind, QtCore.Qt.UserRole))
-        for i in range(survey.rowCount()):
-            obstreeloop = survey.child(i)
-            simpleloop = SimpleLoop(obstreeloop)
-            self.loops.append(simpleloop)
-        self.checked = survey.checkState()
-        self.name = survey.name
-        self.adjoptions = survey.adjustment.adjustmentoptions
-
-
 class SimpleDelta:
     """
     Here we remove the ObsTreeStation objects from the Delta object (because they can't be pickled). Store a reference


### PR DESCRIPTION
In this PR I've removed the SimpleSurvey type and instead modified `ObsTreeSurvey` to permit serialization by jsons. This is done by adding a custom `.to_json()` method which does all the necessary collecting/preparation (basically what was done in SimpleSurvey). You can specify a custom serializer for this type to jsons, which then calls that method. 

The same approach would work for all the others, but I wanted to drop this as a proof of concept first. 

Doing this *will* not allow files to be loaded using the Pickle approach, but this isn't really a *bad* thing as Pickle's allow for arbitrary code execution. Some more information [here](https://root4loot.com/post/exploiting_cpickle/) --- I've done a proof of concept [test.zip](https://github.com/jkennedy-usgs/sgp-gsadjust/files/4517675/test.zip) that when loaded in the application will display a dialog window.

If you're able to stop supporting pickles for the next release, would be a good opportunity to clear this stuff out + simplify the load/save process a bit.
