### PR TITLE
Sort filter proxy implementation.

### DIFF
--- a/gsadjust/GSadjust.py
+++ b/gsadjust/GSadjust.py
@@ -242,7 +242,7 @@ class MainProg(QtWidgets.QMainWindow):
 
         # Set models for the tab views.
         self.tab_adjust.delta_proxy_model.setSourceModel(self.delta_model)
-        self.tab_adjust.datum_view.setModel(self.datum_model)
+        self.tab_adjust.datum_proxy_model.setSourceModel(self.datum_model)
         # self.tab_adjust.datum_proxy_model.setSourceModel(self.datum_model)
         self.datum_model.invalidate_proxy.connect(self.tab_adjust.invalidate_sort)
         self.tab_adjust.results_proxy_model.setSourceModel(self.results_model)

--- a/gsadjust/GSadjust.py
+++ b/gsadjust/GSadjust.py
@@ -2097,7 +2097,7 @@ class MainProg(QtWidgets.QMainWindow):
         if station:
             d = Datum(str(station))
             survey.datums.append(d)
-            self.tab_adjust.datum_view.model().init_data(survey.datums)
+            self.tab_adjust.datum_view.model().sourceModel().init_data(survey.datums)
             # self.tab_adjust.datum_view.model().sourceModel().init_data(survey.datums)
             logging.info('Datum station added: {}'.format(station))
             self.set_window_title_asterisk()

--- a/gsadjust/models/datum.py
+++ b/gsadjust/models/datum.py
@@ -210,5 +210,7 @@ class DatumTableModel(QAbstractTableModel):
         return dn
 
     def init_data(self, data):
+        self.beginResetModel()
         self._data = data
+        self.endResetModel()
         self.layoutChanged.emit()  # Refresh whole view.)

--- a/gsadjust/models/delta.py
+++ b/gsadjust/models/delta.py
@@ -252,7 +252,9 @@ class DeltaTableModel(QtCore.QAbstractTableModel):
             return Qt.Checked
 
     def init_data(self, data):
+        self.beginResetModel()
         self._data = data
+        self.endResetModel()
         self.layoutChanged.emit()  # Refresh whole view.
 
 

--- a/gsadjust/models/result.py
+++ b/gsadjust/models/result.py
@@ -124,5 +124,7 @@ class ResultsTableModel(QtCore.QAbstractTableModel):
         return QVariant()
 
     def init_data(self, data):
+        self.beginResetModel()
         self._data = data
+        self.endResetModel()
         self.layoutChanged.emit()  # Refresh whole view.

--- a/gsadjust/models/roman.py
+++ b/gsadjust/models/roman.py
@@ -123,5 +123,7 @@ class RomanTableModel(QtCore.QAbstractTableModel):
         return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
 
     def init_data(self, data):
+        self.beginResetModel()
         self._data = data
+        self.endResetModel()
         self.layoutChanged.emit()  # Refresh whole view.

--- a/gsadjust/models/roman.py
+++ b/gsadjust/models/roman.py
@@ -98,13 +98,13 @@ class RomanTableModel(QtCore.QAbstractTableModel):
         when role is acting value is Qt.Checked or Qt.Unchecked
         """
         if role == Qt.CheckStateRole and index.column() == 0:
-            datum = self.datums[index.row()]
+            datum = self._data[index.row()]
             datum.checked = value
             return True
 
         if role == Qt.EditRole:
             if index.isValid() and index.row() >= 0 and value:
-                datum = self.datums[index.row()]
+                datum = self._data[index.row()]
                 column = index.column()
 
                 if column == DATUM_STATION:

--- a/gsadjust/models/tare.py
+++ b/gsadjust/models/tare.py
@@ -157,5 +157,7 @@ class TareTableModel(QAbstractTableModel):
             return Qt.Checked
 
     def init_data(self, data):
+        self.beginResetModel()
         self._data = data
+        self.endResetModel()
         self.layoutChanged.emit()  # Refresh whole view.


### PR DESCRIPTION
This adds QSortFilterProxy sorting proxy models to the drift tab as an example. I chose this as I could see something there that could explain the issues you were experiencing before.

See the comments on the source for details.